### PR TITLE
Fix compilation for non-editor targets

### DIFF
--- a/Source/NiagaraDestructionDriver/NiagaraDestructionDriver.Build.cs
+++ b/Source/NiagaraDestructionDriver/NiagaraDestructionDriver.Build.cs
@@ -48,10 +48,8 @@ public class NiagaraDestructionDriver : ModuleRules
 				"Engine",
 				"Slate",
 				"SlateCore",
-				"EditorScriptingUtilities", 
 				"MeshConversion", 
-				"Eigen", 
-				"UnrealEd",
+				"Eigen"
 				// ... add private dependencies that you statically link with here ...	
 			}
 			);


### PR DESCRIPTION
This PR fixes #2 by removing the editor modules from the game target. 

I tested development editor and development builds to ensure it still compiles.
